### PR TITLE
Update autoloader to allow module classes in top-level namespaces

### DIFF
--- a/Global/Functions.php
+++ b/Global/Functions.php
@@ -44,12 +44,21 @@ function phpwsAutoload($class_name)
     } elseif (isset($_REQUEST['module'])) {
         $module = preg_replace('/\W/', '', $_REQUEST['module']);
         
+        /***
+         * If the module name is the first token in the class name,
+         * then remove it. Example:
+         * Class name: 'Intern/Command/ShowAddInternship'
+         * Should map to file: 'phpwebsite/mod/intern/class/Command/ShowAddInternship.php'
+         * 
+         * In this example, we need to remove 'Intern/' from the class name in order to generate
+         * the correct file name.
+         */
         if(preg_match("/^$module\//i", $class_name)) {
             $class_name = preg_replace("/^$module\//i", '', $class_name);
         }
         
         $class_file = PHPWS_SOURCE_DIR . "mod/$module/class/$class_name.php";
-        var_dump($class_file);
+        
         if (is_file($class_file)) {
             $files_found[$class_name] = $class_file;
             require_once $class_file;


### PR DESCRIPTION
This change updates the auto-loader to allow modules classes to be in their own top level namespaces.

For example, the class `Intern\Command\ShowAddInternship` is in the namespace `Intern\Command\`. The class files resides in `mod/intern/class/Command/ShowAddInternship.php`.

This change modifies the way the way the file path is constructed in order to remove the `Intern\` from the namepsace path, so that the correct file path is generated.

Please test against other modules, because I can't promise this doesn't break other things.
