### PR TITLE
Fix saving of sub-permissions in Users mod.

### DIFF
--- a/mod/users/class/Action.php
+++ b/mod/users/class/Action.php
@@ -1028,6 +1028,10 @@ class User_Action
 
         $module_permission = $_POST['module_permission'];
         
+        if(isset($_POST['sub_permission'])) {
+            $sub_permission = $_POST['sub_permission'];
+        }
+
         foreach ($module_permission as $mod_title => $permission) {
             $subpermission = isset($sub_permission[$mod_title]) ? $sub_permission[$mod_title] : null;
             Users_Permission::setPermissions($group_id, $mod_title, $permission, $subpermission);


### PR DESCRIPTION
It looks like saving sub-permissions was broken in a28f84c014dc8e107c90b7acbc3e8ae9a3eb9f33 

The sub-permission code was relying on the call to `extract($_POST)` in order to populate data in `$sub_permission`. Commenting out the call to `extract()` caused `$sub_permisson` to always be null, thus no sub-permissions could be saved.