### PR TITLE
Fix link class to handle link text '0'

### DIFF
--- a/core/class/Link.php
+++ b/core/class/Link.php
@@ -41,7 +41,8 @@ class PHPWS_Link {
     public function get()
     {
         $this->loadAddress();
-        if (!$this->address || !$this->label ) {
+        if ($this->address === '' || $this->label === '')
+        {
             return null;
         }
 


### PR DESCRIPTION
Changed the link class so that it no longer returns null for a link text of '0'. Refs AppStateESS/homestead#1061 