### PR TITLE
Use single quotes in regexp to avoid variable interpolation

### DIFF
--- a/mod/menu/class/Menu_Link.php
+++ b/mod/menu/class/Menu_Link.php
@@ -244,7 +244,7 @@ class Menu_Link {
             $redirect_url = preg_quote(PHPWS_Core::getCurrentUrl());
         }
 
-        if (preg_match('@$redirect_url$@', $this->url)) {
+        if (preg_match('#' . $redirect_url . '$#', $this->url)) {
             return true;
         } else {
             return false;

--- a/mod/menu/class/Menu_Link.php
+++ b/mod/menu/class/Menu_Link.php
@@ -244,7 +244,7 @@ class Menu_Link {
             $redirect_url = preg_quote(PHPWS_Core::getCurrentUrl());
         }
 
-        if (preg_match("@$redirect_url$@", $this->url)) {
+        if (preg_match('@$redirect_url$@', $this->url)) {
             return true;
         } else {
             return false;


### PR DESCRIPTION
In the line: `preg_match("@$redirect_url$@")`.. The double quotes are causing `$@` to be interpolated as a PHP variable, when the `$` is really a regexp anchor, and `@` is the delimiter for the end of the regexp. 

Replaced with single quotes and concatenation to use the regexp as a string literal.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/197608664378684/197607776336906)
