### PR TITLE
Update Menu.php

### DIFF
--- a/mod/menu/class/Menu.php
+++ b/mod/menu/class/Menu.php
@@ -444,12 +444,12 @@ class Menu {
             if ($active) {
                 if ($menu->assoc_key) {
                     Layout::set($menu->view(), 'menu', 'side');
-                }
+                }              
+            }            
 
-                if ($menu->assoc_image) {
+            if ($menu->assoc_image) {
                     Layout::set($menu->showAssocImage(), 'menu', 'image');
                 }
-            }
 
             $menu_tpl['menus'][] = self::getCategoryViewLine($menu, $active);
         }


### PR DESCRIPTION
associated menu image was not displaying on homepage. this would conflict with the carousel mod if that is loaded and active as both the associated menu image and the carousel would appear on the homepage. Maybe a flag to check for carousel?