### PR TITLE
Remove setup check for 'magic_quotes' config

### DIFF
--- a/setup/class/Setup.php
+++ b/setup/class/Setup.php
@@ -898,12 +898,6 @@ class Setup
         $test['globals']['name'] = 'Register globals disabled';
         $test['globals']['crit'] = false;
 
-        $test['magic_quotes']['pass'] = !get_magic_quotes_gpc() && !get_magic_quotes_runtime();
-        $test['magic_quotes']['fail'] = dgettext('core',
-                'Magic quotes is enabled. Please disable it in your php.ini file.');
-        $test['magic_quotes']['name'] = 'Magic quotes disabled';
-        $test['magic_quotes']['crit'] = true;
-
         foreach ($test as $test_section => $val) {
             if (!$val['pass']) {
                 if ($val['crit']) {


### PR DESCRIPTION
The Setup class currently checks the PHP configuration for the 'magic_quotes' feature to ensure it's turned off. The `get_magic_quotes_gpc` and `get_magic_quotes_runtime` methods are deprecated in php 7.4 and removed in php 8. This currently causes the installer to fail under PHP 7.4+. The magic_quotes feature was disabled in v5.4, and now the methods to test for it are also being removed, so this check is no longer needed.


References:
https://www.php.net/manual/en/function.get-magic-quotes-gpc.php
https://www.php.net/manual/en/function.get-magic-quotes-runtime.php
https://www.php.net/manual/en/migration74.deprecated.php
https://www.php.net/manual/en/migration80.incompatible.php