### PR TITLE
Updates for PHP 7.2

### DIFF
--- a/docker_web/Dockerfile
+++ b/docker_web/Dockerfile
@@ -5,17 +5,20 @@ USER root
 # install php7 when canopy core is ready
 RUN rpm -Uvh http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 RUN rpm -Uvh https://mirror.webtatic.com/yum/el7/webtatic-release.rpm
-RUN yum -y install php70w php70w-fpm php70w-common php70w-mysql php70w-pgsql php70w-devel php70w-pear php70w-gd php70w-pecl-memcache php70w-pspell php70w-snmp php70w-xmlrpc php70w-xml php70w-soap;
+#RUN yum -y install php70w php70w-fpm php70w-common php70w-mysql php70w-pgsql php70w-devel php70w-pear php70w-gd php70w-pecl-memcache php70w-pspell php70w-snmp php70w-xmlrpc php70w-xml php70w-soap;
+#RUN yum -y install php71w php71w-fpm php71w-common php71w-mysql php71w-pgsql php71w-devel php71w-pear php71w-gd php71w-pecl-memcache php71w-pspell php71w-snmp php71w-xmlrpc php71w-xml php71w-soap;
+RUN yum -y install php71w php72w-fpm php72w-common php72w-mysql php72w-pgsql php72w-devel php72w-pear php72w-gd php72w-pecl-memcache php72w-pspell php72w-snmp php72w-xmlrpc php72w-xml php72w-soap php72w-mbstring;
 #RUN yum -y install php php-common php-mysql php-pgsql php-devel php-gd php-pecl-memcache php-pspell php-snmp php-xmlrpc php-xml php-pear;
-RUN yum -y install phpmyadmin phpPgAdmin vim
+#RUN yum -y install phpmyadmin phpPgAdmin vim
+#RUN yum -y install vim
+#RUN yum -y install nginx
+RUN yum -y install gcc make vim nginx zip
 RUN yum -y update
-RUN yum -y install gcc make
-RUN yum -y install nginx
 RUN pecl install Xdebug
-ADD docker_conf/phpMyAdmin.conf /etc/httpd/conf.d/phpMyAdmin.conf
-ADD docker_conf/phpPgAdmin.conf /etc/httpd/conf.d/phpPgAdmin.conf
-ADD docker_conf/myadmin_config.inc.php /etc/phpMyAdmin/config.inc.php
-ADD docker_conf/pgadmin_config.inc.php /etc/phpPgAdmin/config.inc.php
+#ADD docker_conf/phpMyAdmin.conf /etc/httpd/conf.d/phpMyAdmin.conf
+#ADD docker_conf/phpPgAdmin.conf /etc/httpd/conf.d/phpPgAdmin.conf
+#ADD docker_conf/myadmin_config.inc.php /etc/phpMyAdmin/config.inc.php
+#ADD docker_conf/pgadmin_config.inc.php /etc/phpPgAdmin/config.inc.php
 ADD docker_conf/xdebug.ini /etc/php.d/xdebug.ini
 
 RUN mkdir /etc/nginx/conf.d/common

--- a/lib/pear/File.php
+++ b/lib/pear/File.php
@@ -378,7 +378,8 @@ class File extends PEAR
         $filePointers = &PEAR::getStaticProperty('File', 'filePointers');
 
         // unlock files
-        for ($i = 0, $c = count($locks); $i < $c; $i++) {
+        $c = is_array($locks) ? count($locks) : 0;
+        for ($i = 0; $i < $c; $i++) {
             is_resource($locks[$i]) and @flock($locks[$i], LOCK_UN);
         }
 

--- a/mod/notification/class/NQ.php
+++ b/mod/notification/class/NQ.php
@@ -17,7 +17,7 @@ class NQ
 
     public static function close()
     {
-        if(count(self::$queues) > 0) {
+        if(is_array(self::$queues) && count(self::$queues) > 0) {
             $_SESSION['NotificationQueue'] = serialize(self::$queues);
         } else {
             if(isset($_SESSION['NotificationQueue'])) {

--- a/setup/class/Setup.php
+++ b/setup/class/Setup.php
@@ -898,12 +898,6 @@ class Setup
         $test['globals']['name'] = 'Register globals disabled';
         $test['globals']['crit'] = false;
 
-        $test['magic_quotes']['pass'] = !get_magic_quotes_gpc() && !get_magic_quotes_runtime();
-        $test['magic_quotes']['fail'] = dgettext('core',
-                'Magic quotes is enabled. Please disable it in your php.ini file.');
-        $test['magic_quotes']['name'] = 'Magic quotes disabled';
-        $test['magic_quotes']['crit'] = true;
-
         foreach ($test as $test_section => $val) {
             if (!$val['pass']) {
                 if ($val['crit']) {

--- a/setup/class/Setup.php
+++ b/setup/class/Setup.php
@@ -417,7 +417,7 @@ class Setup
         $mdb2_connection = $tdb->connect($dsn);
         if ($mdb2_connection->isConnected()) {
             $tables = $mdb2_connection->listTables();
-            if (count($tables)) {
+            if ($tables !== null && count($tables) > 0) {
                 return 2;
             } else {
                 $this->setConfigSet('dsn', $dsn);


### PR DESCRIPTION
* Update Dockerfile to use PHP 7.2.
* Minor fixes for count() [backwards-incompatible changes](https://www.php.net/manual/en/migration72.incompatible.php)
* Remove `magic_quotes` checking during setup, as magic quotes [were removed in php 5.4](https://www.php.net/manual/en/info.configuration.php#ini.magic-quotes-runtime).  `get_magic_quotes_runtime()` is [deprecated](https://www.php.net/manual/en/function.get-magic-quotes-runtime.php) as of 7.4.0.